### PR TITLE
Add global theme toggle to all pages

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -4,11 +4,21 @@
     <title>Artificial -and- Talentless - Generate</title>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
     <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
     
 <link rel="stylesheet" href="style.css"></head>
 <body>
+    <div id="header-content" class="global">
+        <div id="theme-toggle-switch-container">
+            <div id="theme-toggle-icons">
+                <i class="fas fa-sun" id="light-icon"></i>
+                <i class="fas fa-moon" id="dark-icon"></i>
+            </div>
+        </div>
+    </div>
     <!-- Main content area for the loading message, spinner, or generated content -->
     <div id="main-content-area" class="generate">
         <p id="display-content" class="content-display"></p>
@@ -24,5 +34,5 @@
     
 
 
-
+    <script src="js/theme.js"></script>
 <script src="js/generator.js"></script></body></html>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <title>Artificial -and- Talentless</title>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
     <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
     
@@ -24,7 +26,7 @@
                 <i class="fas fa-moon" id="dark-icon"></i>
             </div>
         </div>
-    </div
+    </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
         <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/FFFFE3?text=Logo'" data-dark-src="assets/logo-dark.png">

--- a/intro.html
+++ b/intro.html
@@ -11,13 +11,7 @@
     
 <link rel="stylesheet" href="style.css"></head>
 <body>
-    <div id="theme-toggle-switch-container">
-        <div id="theme-toggle-icons">
-            <i class="fas fa-sun" id="light-icon"></i>
-            <i class="fas fa-moon" id="dark-icon"></i>
-        </div>
-    </div>
-<div id="header-content" class="settings">
+    <div id="header-content" class="global">
         <div id="theme-toggle-switch-container">
             <!-- The switch HTML structure -->
             <div id="theme-toggle-icons">

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,45 +1,40 @@
-// Theme management including logo switching
-function toggleTheme() {
-    const html = document.documentElement;
-    const isDark = html.classList.toggle('dark');
-    localStorage.setItem('dark-mode', isDark);
-    updateLogoForTheme(isDark);
-}
-
-function updateLogoForTheme(isDark) {
-    const logo = document.getElementById('logo');
-    if (!logo) return;
-
-    const darkSrc = logo.dataset.darkSrc;
-    const currentSrc = logo.src;
-    
-    if (isDark && darkSrc && !currentSrc.endsWith('logo-dark.png')) {
-        logo.dataset.lightSrc = currentSrc;
-        logo.src = darkSrc;
-    } else if (!isDark && logo.dataset.lightSrc && currentSrc.endsWith('logo-dark.png')) {
-        logo.src = logo.dataset.lightSrc;
-    }
-}
-
-function initTheme() {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const storedDark = localStorage.getItem('dark-mode');
-    const darkMode = storedDark ? JSON.parse(storedDark) : prefersDark;
-
-    if (darkMode) {
-        document.documentElement.classList.add('dark');
-    }
-    updateLogoForTheme(darkMode);
-}
-
-function setupThemeToggle() {
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-        themeToggle.addEventListener('click', toggleTheme);
-    }
-}
-
+// Global theme toggling using sun/moon icons
 document.addEventListener('DOMContentLoaded', () => {
-    initTheme();
-    setupThemeToggle();
+    const body = document.body;
+    const lightIcon = document.getElementById('light-icon');
+    const darkIcon = document.getElementById('dark-icon');
+
+    function applyTheme(theme) {
+        if (theme === 'dark') {
+            body.classList.add('dark-mode');
+            if (lightIcon) lightIcon.style.display = 'none';
+            if (darkIcon) darkIcon.style.display = 'inline-block';
+        } else {
+            body.classList.remove('dark-mode');
+            if (lightIcon) lightIcon.style.display = 'inline-block';
+            if (darkIcon) darkIcon.style.display = 'none';
+        }
+        localStorage.setItem('theme', theme);
+
+        // Swap images if a dark version is provided
+        document.querySelectorAll('img[data-dark-src]').forEach(img => {
+            if (!img.dataset.lightSrc) {
+                img.dataset.lightSrc = img.src;
+            }
+            img.src = theme === 'dark' ? img.dataset.darkSrc : img.dataset.lightSrc;
+        });
+    }
+
+    // Initialize theme from localStorage or default to light
+    applyTheme(localStorage.getItem('theme') || 'light');
+
+    const toggleIcons = document.getElementById('theme-toggle-icons');
+    if (toggleIcons) {
+        toggleIcons.addEventListener('click', () => {
+            const current = localStorage.getItem('theme') || 'light';
+            const next = current === 'light' ? 'dark' : 'light';
+            applyTheme(next);
+        });
+    }
 });
+

--- a/name.html
+++ b/name.html
@@ -11,10 +11,12 @@
     
 <link rel="stylesheet" href="style.css"></head>
 <body>
-    <div id="theme-toggle-switch-container">
-        <div id="theme-toggle-icons">
-            <i class="fas fa-sun" id="light-icon"></i>
-            <i class="fas fa-moon" id="dark-icon"></i>
+    <div id="header-content" class="global">
+        <div id="theme-toggle-switch-container">
+            <div id="theme-toggle-icons">
+                <i class="fas fa-sun" id="light-icon"></i>
+                <i class="fas fa-moon" id="dark-icon"></i>
+            </div>
         </div>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->

--- a/onboard-settings.html
+++ b/onboard-settings.html
@@ -4,11 +4,21 @@
     <title>Artificial -and- Talentless - Settings</title>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
     <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
     
 <link rel="stylesheet" href="style.css"></head>
 <body>
+    <div id="header-content" class="global">
+        <div id="theme-toggle-switch-container">
+            <div id="theme-toggle-icons">
+                <i class="fas fa-sun" id="light-icon"></i>
+                <i class="fas fa-moon" id="dark-icon"></i>
+            </div>
+        </div>
+    </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
         <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/F7F7D3?text=Logo'" data-dark-src="assets/logo-dark.png">

--- a/questions.html
+++ b/questions.html
@@ -11,10 +11,12 @@
     
 <link rel="stylesheet" href="style.css"></head>
 <body>
-    <div id="theme-toggle-switch-container">
-        <div id="theme-toggle-icons">
-            <i class="fas fa-sun" id="light-icon"></i>
-            <i class="fas fa-moon" id="dark-icon"></i>
+    <div id="header-content" class="global">
+        <div id="theme-toggle-switch-container">
+            <div id="theme-toggle-icons">
+                <i class="fas fa-sun" id="light-icon"></i>
+                <i class="fas fa-moon" id="dark-icon"></i>
+            </div>
         </div>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->


### PR DESCRIPTION
## Summary
- Add Font Awesome and reusable header with sun/moon icons to each page so the theme toggle is visible everywhere.
- Replace legacy theme logic with a shared `theme.js` that toggles `dark-mode`, swaps icons, and updates images based on local storage.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a48afe847c832aac35ddb67f1385f5