### PR TITLE
feat: add theme system and pwa support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .aider*
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# artificial-and-talentless
 # Artificial-and-Talentless
+
+This project is a Progressive Web App that offers light and dark themes with a single `data-theme` attribute on the `<html>` element.
+
+## Features
+- Theme preference (`light`, `dark`, or `system`) is saved to `localStorage` and applied before the first paint to avoid flashes of unstyled content.
+- Toggle button available on every page except `generator.html` with proper `aria-pressed` state and icon swaps.
+- Service worker uses a Stale-While-Revalidate caching strategy to provide offline support.
+- `manifest.webmanifest` defines install metadata and icons for Android/Chrome.
+- Custom install banner shown on each visit until the user installs or dismisses it for the session.
+
+## Testing Installability
+1. Serve the project over **HTTPS**.
+2. Open Chrome DevTools ➜ **Application** ➜ **Manifest** to verify the manifest and service worker registration.
+3. Use the **Lighthouse** panel to audit PWA installability and offline readiness.
+
+## Generating an Android APK
+1. Install Bubblewrap: `npm i -g @bubblewrap/cli`.
+2. Run `bubblewrap init --manifest=https://YOUR_DOMAIN/manifest.webmanifest`.
+3. Follow the prompts, then execute `bubblewrap build` to create the signed APK.
+4. The resulting APK can be uploaded to the Play Store or sideloaded on devices.
+

--- a/generator.html
+++ b/generator.html
@@ -1,15 +1,30 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Generate</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <!-- Main content area for the loading message, spinner, or generated content -->
     <div id="main-content-area" class="generate">
@@ -23,8 +38,8 @@
         <button id="settings-button" class="nav-button">Settings</button>
     </div>
 
-    
-
-
+    <script src="js/generator.js"></script>
+    <script src="js/pwa.js"></script>
     <script src="js/theme.js"></script>
-<script src="js/generator.js"></script></body></html>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,6 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FFFFE3">
@@ -9,21 +11,32 @@
     <link rel="apple-touch-icon" href="assets/icon.png">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
-    <div id="header-content" class="global"> <div id="theme-toggle-switch-container">
-           <button id="theme-toggle" aria-pressed="false" aria-label="Toggle theme">
-  <i class="fas fa-sun" id="light-icon"></i>
-  <i class="fas fa-moon" id="dark-icon"></i>
-</button>
-        </div>
+    <div id="header-content" class="global">
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+          <i class="fas fa-sun" aria-hidden="true"></i>
+          <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
@@ -41,12 +54,11 @@
 
     <!-- Footer for the button, fixed at the bottom -->
     <div id="button-footer">
-        <button id="get-started-button"class="nav-button">Get Started</button>
+        <button id="get-started-button" class="nav-button">Get Started</button>
     </div>
 
-    
-
-
-
-<script src="js/theme.js"></script>
-<script src="js/index.js"></script></body></html>
+    <script src="js/index.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/intro.html
+++ b/intro.html
@@ -1,24 +1,36 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Onboarding</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <div id="header-content" class="global">
-        <div id="theme-toggle-switch-container">
-            <!-- The switch HTML structure -->
-            <div id="theme-toggle-icons">
-                <i class="fas fa-sun" id="light-icon"></i>
-                <i class="fas fa-moon" id="dark-icon"></i>
-            </div>
-        </div>
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
@@ -36,9 +48,8 @@
         <button id="continue-button" class="nav-button">Continue</button>
     </div>
 
-    
-
-
-
-<script src="js/theme.js"></script>
-<script src="js/intro.js"></script></body></html>
+    <script src="js/intro.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,54 @@
+(function () {
+  const DISMISSED_KEY = 'pwa-install-dismissed';
+  let deferredPrompt;
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
+
+  function showInstallBanner() {
+    if (sessionStorage.getItem(DISMISSED_KEY)) return;
+    const banner = document.createElement('div');
+    banner.id = 'install-banner';
+    banner.style.position = 'fixed';
+    banner.style.bottom = '20px';
+    banner.style.left = '50%';
+    banner.style.transform = 'translateX(-50%)';
+    banner.style.background = 'var(--bg-alt)';
+    banner.style.color = 'var(--text)';
+    banner.style.padding = '10px 20px';
+    banner.style.borderRadius = 'var(--radius)';
+    banner.style.boxShadow = '0 4px 6px var(--shadow)';
+    const installBtn = document.createElement('button');
+    installBtn.textContent = 'Install';
+    installBtn.style.marginRight = '10px';
+    const dismissBtn = document.createElement('button');
+    dismissBtn.textContent = 'Dismiss';
+    banner.appendChild(installBtn);
+    banner.appendChild(dismissBtn);
+    document.body.appendChild(banner);
+
+    installBtn.addEventListener('click', async () => {
+      if (!deferredPrompt) return;
+      deferredPrompt.prompt();
+      await deferredPrompt.userChoice;
+      deferredPrompt = null;
+      sessionStorage.setItem(DISMISSED_KEY, '1');
+      banner.remove();
+    });
+
+    dismissBtn.addEventListener('click', () => {
+      sessionStorage.setItem(DISMISSED_KEY, '1');
+      banner.remove();
+    });
+  }
+
+  window.addEventListener('beforeinstallprompt', (e) => {
+    if (window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone) {
+      return;
+    }
+    e.preventDefault();
+    deferredPrompt = e;
+    showInstallBanner();
+  });
+})();

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -4,6 +4,7 @@
   "description": "AI-powered personalized insult generator",
   "start_url": "/",
   "display": "standalone",
+  "orientation": "portrait",
   "background_color": "#FFFFE3",
   "theme_color": "#000000",
   "icons": [
@@ -14,15 +15,21 @@
       "purpose": "any"
     },
     {
-      "src": "assets/icon-dark.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
       "src": "assets/icon.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    }
+  ],
+  "categories": ["entertainment"],
+  "shortcuts": [
+    {
+      "name": "Generate",
+      "short_name": "Generate",
+      "url": "/generator.html",
+      "icons": [
+        { "src": "assets/icon.png", "sizes": "192x192", "type": "image/png" }
+      ]
     }
   ]
 }

--- a/name.html
+++ b/name.html
@@ -1,23 +1,36 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <div id="header-content" class="global">
-        <div id="theme-toggle-switch-container">
-            <div id="theme-toggle-icons">
-                <i class="fas fa-sun" id="light-icon"></i>
-                <i class="fas fa-moon" id="dark-icon"></i>
-            </div>
-        </div>
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
@@ -38,9 +51,8 @@
         <button id="continue-button" class="nav-button">Continue</button>
     </div>
 
-    
-
-
-
-<script src="js/theme.js"></script>
-<script src="js/name.js"></script></body></html>
+    <script src="js/name.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/onboard-settings.html
+++ b/onboard-settings.html
@@ -1,23 +1,36 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Settings</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <div id="header-content" class="global">
-        <div id="theme-toggle-switch-container">
-            <div id="theme-toggle-icons">
-                <i class="fas fa-sun" id="light-icon"></i>
-                <i class="fas fa-moon" id="dark-icon"></i>
-            </div>
-        </div>
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
@@ -68,9 +81,8 @@
         <button id="next-button" class="nav-button">Finish</button>
     </div>
 
-    
-
-
-
-<script src="js/theme.js"></script>
-<script src="js/onboard-settings.js"></script></body></html>
+    <script src="js/onboard-settings.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/questions.html
+++ b/questions.html
@@ -1,23 +1,36 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Onboarding</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <div id="header-content" class="global">
-        <div id="theme-toggle-switch-container">
-            <div id="theme-toggle-icons">
-                <i class="fas fa-sun" id="light-icon"></i>
-                <i class="fas fa-moon" id="dark-icon"></i>
-            </div>
-        </div>
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
@@ -109,9 +122,8 @@
         <button id="next-button" class="nav-button">Next</button>
     </div>
 
-    
-
-
-
-<script src="js/theme.js"></script>
-<script src="js/questions.js"></script></body></html>
+    <script src="js/questions.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/settings.html
+++ b/settings.html
@@ -1,26 +1,38 @@
-<!DOCTYPE html><html lang="en" class="light"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Settings</title>
+    <script>
+      (function () {
+        const KEY = 'app:theme';
+        const stored = localStorage.getItem(KEY) || 'system';
+        const resolved = stored === 'system'
+          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : stored;
+        const root = document.documentElement;
+        root.setAttribute('data-theme', resolved);
+        root.style.colorScheme = resolved;
+      })();
+    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Google Fonts: Special Elite for that vintage typewriter feel -->
-    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&amp;display=swap" rel="stylesheet">
-    
-<link rel="stylesheet" href="style.css"></head>
+    <link href="https://fonts.googleapis.com/css2?family=Special+Elite&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
 <body>
     <!-- New fixed header for title and theme toggle -->
     <div id="header-content" class="settings">
         <h1 id="settings-main-title">Settings</h1>
-        <div id="theme-toggle-switch-container">
-            <!-- The switch HTML structure -->
-            <div id="theme-toggle-icons">
-                <i class="fas fa-sun" id="light-icon"></i>
-                <i class="fas fa-moon" id="dark-icon"></i>
-            </div>
-        </div>
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
     </div>
 
     <!-- Main content area for displaying settings -->
@@ -74,9 +86,9 @@
         <button id="save-settings-button" class="nav-button">Save</button>
     </div>
 
-    
-
-
-<!-- At the bottom of settings.html, before </body> -->
-<script src="js/theme.js"></script>
-<script src="js/settings.js"></script></body></html>
+    <!-- At the bottom of settings.html, before </body> -->
+    <script src="js/settings.js"></script>
+    <script src="js/pwa.js"></script>
+    <script src="js/theme.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -6,22 +6,21 @@
 /* 1) CSS Variables (light mode defaults) */
 :root {
   /* Palette */
-  --bg: #FFFFE3;        /* light cream (was #FFFFE3 / #F7F7D3 mix) */
+  --bg: #FFFFE3;
   --bg-alt: #F7F7D3;
   --text: #000000;
   --text-muted: #1A1A1A;
-  --accent: #000000;    /* primary accent for generic buttons */
+  --accent: #000000;
   --accent-contrast: #ffffff;
   --border: #000000;
   --shadow: rgba(0,0,0,.12);
 
-  /* Dark mode palette */
-  --bg-dark: #000000;
-  --bg-alt-dark: #1A1A1A;
-  --text-dark: #FFFFE3;
-  --accent-dark: #FFFFE3;
-  --border-dark: #FFFFE3;
-  --shadow-dark: rgba(247,247,211,.16);
+  /* Layout */
+  --max-content: 500px;
+  --logo-max: 350px;
+  --logo-max-lg: 200px;
+  --page-pad-top: 120px;
+  --page-pad-bot: 70px;
 
   /* Sizing + radius */
   --radius: 10px;
@@ -44,46 +43,36 @@
   --fs-sm: .95rem;
   --fs-md: 1rem;
   --fs-lg: 1.3rem;
-  --fs-xl: 3rem;   /* h1 base */
-  --fs-xxl: 5rem;  /* h1 on mobile hero */
-  --fs-larger: 1.5rem;  /* h1 on mobile hero */
-  --fs-xxxl: 2rem; /* add this so h3 doesn’t reference an undefined var */
+  --fs-xl: 3rem;
+  --fs-xxl: 5rem;
+  --fs-larger: 1.5rem;
+  --fs-xxxl: 2rem;
 }
 
-  /* Layout */
-  --max-content: 500px;
-  --logo-max: 350px;
-  --logo-max-lg: 200px;
-  --page-pad-top: 120px;   /* space for fixed header/logo */
-  --page-pad-bot: 70px;    /* space for fixed footer */
-}
-
-/* 2) Dark mode: flip variables by scoping to body.dark-mode */
-body.dark-mode {
-  --bg: var(--bg-dark);
-  --bg-alt: var(--bg-alt-dark);
-  --text: var(--text-dark);
-  --text-muted: var(--text-dark);
-  --accent: var(--accent-dark);
+/* Dark-mode overrides */
+[data-theme="dark"] {
+  --bg: #000000;
+  --bg-alt: #1A1A1A;
+  --text: #FFFFE3;
+  --text-muted: #FFFFE3;
+  --accent: #FFFFE3;
   --accent-contrast: #121212;
-  --border: var(--border-dark);
-  --shadow: var(--shadow-dark);
+  --border: #FFFFE3;
+  --shadow: rgba(247,247,211,.16);
 }
 
 /* 3) Base / Reset-ish */
-*,
-*::before,
-*::after { box-sizing: border-box; }
+*, *::before, *::after { box-sizing: border-box; }
 
 html, body {
+  background: var(--bg);
+  color: var(--text);
   height: 100%;
 }
 
 body {
   margin: 0;
   font-family: var(--font-ui);
-  background-color: var(--bg);
-  color: var(--text);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -258,7 +247,7 @@ h1 {
   margin: 0 0 var(--space-6);
   text-align: center;
 }
-body.dark-mode h1 { color: var(--text); }
+[data-theme='dark'] h1 { color: var(--text); }
 
 p, .intro-text, .content-display {
   font-size: var(--fs-lg);
@@ -345,7 +334,7 @@ select {
   padding-right: 34px;
   background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 256 512%22%3E%3Cpath fill=%22%230A0518%22 d=%22M192 424.4l-96-96 96-96 22.6 22.6-67.4 67.4 67.4 67.4z%22/%3E%3C/svg%3E');
 }
-body.dark-mode select {
+[data-theme='dark'] select {
   background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 256 512%22%3E%3Cpath fill=%22%23FFFFE3%22 d=%22M192 424.4l-96-96 96-96 22.6 22.6-67.4 67.4 67.4 67.4z%22/%3E%3C/svg%3E');
 }
 
@@ -361,7 +350,7 @@ body.dark-mode select {
   width: 18px; height: 18px;
   accent-color: var(--text);
 }
-body.dark-mode .checkbox-container input[type="checkbox"] {
+[data-theme='dark'] .checkbox-container input[type="checkbox"] {
   accent-color: var(--text);
 }
 .checkbox-container label {
@@ -411,7 +400,7 @@ body.dark-mode .checkbox-container input[type="checkbox"] {
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-body.dark-mode .spinner {
+[data-theme='dark'] .spinner {
   border-color: rgba(247,247,211,.2);
   border-left-color: var(--text);
 }
@@ -493,31 +482,22 @@ body.dark-mode .spinner {
 }
 
 /* 17) Theme toggle icons */
-#theme-toggle-icons {
+#theme-toggle {
   cursor: pointer;
   font-size: 1.1rem;
   padding: 5px;
   display: flex;
   gap: 10px;
   align-items: center;
-}
-
-#light-icon, #dark-icon {
-  transition: all 0.3s ease;
+  background: none;
+  border: none;
   color: var(--text);
 }
 
-#dark-icon {
-  display: none;
-}
-
-body.dark-mode #light-icon {
-  display: none;
-}
-
-body.dark-mode #dark-icon {
-  display: inline-block;
-}
+#theme-toggle .fa-sun { display: inline; }
+#theme-toggle .fa-moon { display: none; }
+[data-theme='dark'] #theme-toggle .fa-sun { display: none; }
+[data-theme='dark'] #theme-toggle .fa-moon { display: inline; }
 
 #content-type-select {
   align-content: center;

--- a/sw.js
+++ b/sw.js
@@ -1,32 +1,48 @@
-const CACHE_NAME = 'artificial-talented-v1';
+const CACHE_NAME = 'artificial-talented-v2';
 const ASSETS = [
   '/',
   '/index.html',
-  '/name.html', 
   '/intro.html',
+  '/name.html',
   '/questions.html',
   '/onboard-settings.html',
   '/generator.html',
   '/settings.html',
+  '/style.css',
+  '/js/index.js',
+  '/js/intro.js',
+  '/js/name.js',
+  '/js/questions.js',
+  '/js/onboard-settings.js',
+  '/js/generator.js',
+  '/js/settings.js',
+  '/js/pwa.js',
+  '/js/theme.js',
   '/manifest.webmanifest',
   '/assets/logo.png',
   '/assets/logo-dark.png',
   '/assets/icon.png',
-  '/assets/icon-dark.png',
-  'https://cdn.tailwindcss.com',
-  'https://fonts.googleapis.com/css2?family=Special+Elite&display=swap'
+  '/assets/icon-dark.png'
 ];
 
-self.addEventListener('install', (e) => {
-  e.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(ASSETS))
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
 });
 
-self.addEventListener('fetch', (e) => {
-  e.respondWith(
-    caches.match(e.request)
-      .then(response => response || fetch(e.request))
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      const networkFetch = fetch(event.request).then(response => {
+        if (response && response.status === 200) {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+        }
+        return response;
+      }).catch(() => cached);
+      return cached || networkFetch;
+    })
   );
 });


### PR DESCRIPTION
## Summary
- introduce `data-theme` driven light/dark theming with early resolver and toggle button
- add web manifest and service worker with stale-while-revalidate caching
- show persistent install banner and document PWA testing & APK steps

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d0e873ac832ab0e448a234b17742