### PR TITLE
Refactor PWA navigation, theme, and offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ This project is a Progressive Web App that offers light and dark themes with a s
 3. Follow the prompts, then execute `bubblewrap build` to create the signed APK.
 4. The resulting APK can be uploaded to the Play Store or sideloaded on devices.
 
+## Production Tailwind build
+The project currently pulls Tailwind from the CDN during development. For a production build:
+
+1. Install build tools: `npm i -D tailwindcss postcss autoprefixer vite`
+2. Run `npx tailwindcss init -p` and set `content` to `./*.{html,js}`
+3. Create `src/styles/tailwind.css` with `@tailwind base; @tailwind components; @tailwind utilities;`
+4. Build with `npx tailwindcss -i src/styles/tailwind.css -o style.css --minify`
+5. Remove `<script src="https://cdn.tailwindcss.com"></script>` from HTML files.
+

--- a/generator.html
+++ b/generator.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Generate</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -34,10 +22,11 @@
 
     <!-- Global Footer for Navigation Buttons, fixed at the bottom -->
     <div id="button-footer">
-        <button id="generate-new-button" class="nav-button">Generate New</button>
+        <button id="generate-new-button" class="nav-button" disabled>Generate New</button>
         <button id="settings-button" class="nav-button">Settings</button>
     </div>
 
+    <script src="js/message.js"></script>
     <script src="js/generator.js"></script>
     <script src="js/pwa.js"></script>
     <script src="js/theme.js"></script>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,6 @@
     <link rel="apple-touch-icon" href="assets/icon.png">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS via CDN with proper integrity hash - TEMPORARY - prefer local build for production -->
     <!-- Font Awesome for icons with fallback -->
     <link rel="stylesheet" 
@@ -46,7 +34,10 @@
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
-        <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/FFFFE3?text=Logo'" data-dark-src="assets/logo-dark.png">
+        <img id="logo" src="assets/logo.png"
+             data-light-src="assets/logo.png"
+             data-dark-src="assets/logo-dark.png"
+             alt="Artificial —and— Talentless Logo">
     </div>
 
     <!-- Main content area that will center the text vertically -->
@@ -60,7 +51,7 @@
 
     <!-- Footer for the button, fixed at the bottom -->
     <div id="button-footer">
-        <button id="get-started-button" class="nav-button">Get Started</button>
+        <button id="get-started-button" class="nav-button" disabled>Get Started</button>
     </div>
 
     <script src="js/index.js"></script>

--- a/intro.html
+++ b/intro.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Onboarding</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -34,8 +22,10 @@
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
-        <!-- Using logo.png as per previous file uploads, added onerror for robustness -->
-        <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/FFFFE3?text=Logo'" data-dark-src="assets/logo-dark.png">
+        <img id="logo" src="assets/logo.png"
+             data-light-src="assets/logo.png"
+             data-dark-src="assets/logo-dark.png"
+             alt="Artificial —and— Talentless Logo">
     </div>
 
     <!-- Main content area that will center the introduction text vertically -->
@@ -45,7 +35,7 @@
 
     <!-- Footer for the button, fixed at the bottom -->
     <div id="button-footer">
-        <button id="continue-button" class="nav-button">Continue</button>
+        <button id="continue-button" class="nav-button" disabled>Continue</button>
     </div>
 
     <script src="js/intro.js"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -1,68 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('isOnboarded') === 'true') {
+    window.location.href = 'generator.html';
+    return;
+  }
 
-        document.addEventListener('DOMContentLoaded', () => {
-        // 🔁 data-dark-src swap logic
-        document.querySelectorAll("img[data-dark-src]").forEach(img => {
-          if (document.body.classList.contains("dark-mode")) {
-            img.src = img.dataset.darkSrc;
-          }
-        });
-            // Apply theme based on localStorage
-            const theme = localStorage.getItem('theme');
-            if (theme === 'dark') {
-                document.body.classList.add('dark-mode');
-            }
+  const button = document.getElementById('get-started-button');
+  const tagline = document.querySelector('.tagline');
+  const subTagline = document.querySelector('.sub-tagline');
+  const taglineText = 'An AI-powered minimalist typewriter generates personalized insults just for you.';
+  const subTaglineText = "Enjoy. Or don't. Whatever.";
 
-            const getStartedButton = document.getElementById('get-started-button');
-            const tagline = document.querySelector('.tagline');
-            const subTagline = document.querySelector('.sub-tagline');
+  function typeWriter(el, text, i, cb) {
+    if (i < text.length) {
+      if (i === 0) el.textContent = '';
+      el.textContent += text.charAt(i);
+      setTimeout(() => typeWriter(el, text, i + 1, cb), 50 + Math.random() * 50);
+    } else if (cb) {
+      setTimeout(cb, 500);
+    }
+  }
 
-            // Your original tagline texts
-            const taglineText = "An AI-powered minimalist typewriter generates personalized insults just for you.";
-            const subTaglineText = "Enjoy. Or don't. Whatever.";
+  button.disabled = true;
+  setTimeout(() => {
+    typeWriter(tagline, taglineText, 0, () => {
+      typeWriter(subTagline, subTaglineText, 0, () => {
+        button.disabled = false;
+      });
+    });
+  }, 1000);
 
-            // Check if user has already onboarded
-            const isOnboarded = localStorage.getItem('isOnboarded') === 'true';
-            if (isOnboarded) {
-                // Redirect if already onboarded (assuming 'generator.html' is the next page)
-                window.location.href = 'generator.html';
-                return; // Stop further execution on this page
-            }
-
-            /**
-             * Implements a typewriter effect for text elements.
-             * @param {HTMLElement} element - The DOM element to type into.
-             * @param {string} text - The full text to type.
-             * @param {number} i - Current index for typing.
-             * @param {function} [callback] - Function to call after typing is complete.
-             */
-            function typeWriter(element, text, i, callback) {
-                if (i < text.length) {
-                    if (i === 0) {
-                        element.style.visibility = 'visible'; // Make element visible when typing starts
-                        element.innerHTML = ''; // Clear content before typing
-                    }
-                    element.innerHTML += text.charAt(i);
-                    // Random delay for a more natural typewriter feel
-                    setTimeout(() => typeWriter(element, text, i + 1, callback), 50 + Math.random() * 50);
-                } else if (callback) {
-                    setTimeout(callback, 500); // Small delay before calling next function
-                }
-            }
-
-            // Start the typewriter effect after a short delay
-            setTimeout(() => {
-                typeWriter(tagline, taglineText, 0, () => {
-                    typeWriter(subTagline, subTaglineText, 0, () => {
-                        // Make the button visible after both taglines are typed
-                        getStartedButton.style.visibility = 'visible';
-                    });
-                });
-            }, 1000); // Initial delay before typing starts
-
-            // Event listener for the "Get Started" button
-            getStartedButton.addEventListener('click', () => {
-                // Set onboarding status to true and navigate to the next page
-                window.location.href = 'name.html'; // Assuming 'onboarding-name.html' is the next page
-            });
-        });
-    
+  button.addEventListener('click', () => {
+    window.location.href = 'name.html';
+  });
+});

--- a/js/intro.js
+++ b/js/intro.js
@@ -1,90 +1,55 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('isOnboarded') === 'true') {
+    window.location.href = 'generator.html';
+    return;
+  }
 
-        document.addEventListener('DOMContentLoaded', () => {
-        // 🔁 data-dark-src swap logic
-        document.querySelectorAll("img[data-dark-src]").forEach(img => {
-          if (document.body.classList.contains("dark-mode")) {
-            img.src = img.dataset.darkSrc;
-          }
-        });
-            // Apply theme based on localStorage
-            const theme = localStorage.getItem('theme');
-            if (theme === 'dark') {
-                document.body.classList.add('dark-mode');
-            }
+  const continueButton = document.getElementById('continue-button');
+  const introTextElement = document.getElementById('intro-text');
+  const introLines = [
+    "Let's get to know each other, so a therapist can get to know your money a lot better.",
+    "Let's get to know each other so I can start the process of destroying you from the inside out.",
+    "Time for a quick personality check—don't worry, no one gets out of here without a little roast.",
+    "Let me gather some info so I can better insult your life choices in the most personalized way possible.",
+    "Let's figure out what makes you tick, so I can break it down and put it back together wrong.",
+    "I need to know everything about you... for completely healthy and non-suspicious reasons.",
+    "Don't worry, this will only take a minute, and I promise not to make any life-altering judgments... yet.",
+    "Here's a quick survey to help me turn all your quirks into finely crafted insults. You're welcome.",
+    "I'm about to know you better than your best friend does. Brace yourself.",
+    "Before we begin, I need to peer into the soft, writhing core of your personality. Don’t flinch.",
+    "Answer honestly. I already know when you’re lying—I just want to see if you do.",
+    "Let’s unlock your inner self. Then maybe lock it back up, depending on what we find.",
+    "Time to spill your guts—figuratively, unless this app updates poorly.",
+    "Let me map your flaws like constellations. Beautiful, tragic, avoidable.",
+    "I just need some basic info before I decide whether you’re a misunderstood genius or just very online.",
+    "Take a deep breath. This is the part where I psychoanalyze you with all the grace of a chainsaw.",
+    "This short quiz will determine your love language, your deepest fear, and how close you are to a villain arc.",
+    "Let’s learn what drives you—besides caffeine, trauma, and spite.",
+    "You talk, I listen. Then I quietly judge and build a custom roast in the background.",
+    "Let's do this quick—like ripping off a personality bandage.",
+    "Think of this as foreplay for emotional vulnerability. But with less touching. Hopefully.",
+    "I'm basically a fortune teller with Wi-Fi. Tell me everything.",
+    "I need your data. Not for evil. Probably."
+  ];
 
-            const userNameSpan = document.getElementById('user-name');
-            const storedUserName = localStorage.getItem('userName');
+  const selectedIntro = introLines[Math.floor(Math.random() * introLines.length)];
 
-            // Display the stored user name
-            if (userNameSpan && storedUserName) {
-                userNameSpan.textContent = storedUserName;
-            } else if (userNameSpan) {
-                // Fallback if no name is found (shouldn't happen if previous page works)
-                userNameSpan.textContent = 'Valued User';
-            }
+  function typeWriter(el, text, i, cb) {
+    if (i < text.length) {
+      if (i === 0) el.textContent = '';
+      el.textContent += text.charAt(i);
+      setTimeout(() => typeWriter(el, text, i + 1, cb), 30 + Math.random() * 70);
+    } else if (cb) {
+      setTimeout(cb, 1500);
+    }
+  }
 
-            const continueButton = document.getElementById('continue-button');
-            const introTextElement = document.getElementById('intro-text'); // Correctly get element by ID
+  continueButton.disabled = true;
+  typeWriter(introTextElement, selectedIntro, 0, () => {
+    continueButton.disabled = false;
+  });
 
-            const introLines = [
-                "Let's get to know each other, so a therapist can get to know your money a lot better.",
-                "Let's get to know each other so I can start the process of destroying you from the inside out.",
-                "Time for a quick personality check—don't worry, no one gets out of here without a little roast.",
-                "Let me gather some info so I can better insult your life choices in the most personalized way possible.",
-                "Let's figure out what makes you tick, so I can break it down and put it back together wrong.",
-                "I need to know everything about you... for completely healthy and non-suspicious reasons.",
-                "Don't worry, this will only take a minute, and I promise not to make any life-altering judgments... yet.",
-                "Here's a quick survey to help me turn all your quirks into finely crafted insults. You're welcome.",
-                "I'm about to know you better than your best friend does. Brace yourself.",
-                "Before we begin, I need to peer into the soft, writhing core of your personality. Don’t flinch.",
-                "Answer honestly. I already know when you’re lying—I just want to see if you do.",
-                "Let’s unlock your inner self. Then maybe lock it back up, depending on what we find.",
-                "Time to spill your guts—figuratively, unless this app updates poorly.",
-                "Let me map your flaws like constellations. Beautiful, tragic, avoidable.",
-                "I just need some basic info before I decide whether you’re a misunderstood genius or just very online.",
-                "Take a deep breath. This is the part where I psychoanalyze you with all the grace of a chainsaw.",
-                "This short quiz will determine your love language, your deepest fear, and how close you are to a villain arc.",
-                "Let’s learn what drives you—besides caffeine, trauma, and spite.",
-                "You talk, I listen. Then I quietly judge and build a custom roast in the background.",
-                "Let's do this quick—like ripping off a personality bandage.",
-                "Think of this as foreplay for emotional vulnerability. But with less touching. Hopefully.",
-                "I'm basically a fortune teller with Wi-Fi. Tell me everything.",
-                "I need your data. Not for evil. Probably."
-            ];
-
-            const randomIndex = Math.floor(Math.random() * introLines.length);
-            const selectedIntro = introLines[randomIndex];
-
-            /**
-             * Implements a typewriter effect for text elements.
-             * @param {HTMLElement} element - The DOM element to type into.
-             * @param {string} text - The full text to type.
-             * @param {number} i - Current index for typing.
-             * @param {function} [callback] - Function to call after typing is complete.
-             */
-            function typeWriter(element, text, i, callback) {
-                if (i < text.length) {
-                    if (element.innerHTML === '') element.style.visibility = 'visible';
-                    element.innerHTML += text.charAt(i);
-                    setTimeout(() => typeWriter(element, text, i + 1, callback), 30 + Math.random() * 70);
-                } else if (callback) setTimeout(callback, 1500);
-            }
-
-            // Start typing the intro text after setting the username
-            // We ensure introTextElement is available before calling typeWriter
-            if (introTextElement) {
-                typeWriter(introTextElement, selectedIntro, 0, () => {
-                    // This callback now just enables the button, it doesn't navigate
-                    // Navigation will happen on button click
-                    continueButton.style.visibility = 'visible'; // Make button visible after text is typed
-                });
-            }
-
-
-            // Event listener for the "Continue" button
-            continueButton.addEventListener('click', () => {
-                // Navigate to the next onboarding page (onboarding questions)
-                window.location.href = 'questions.html'; // Placeholder for the next page
-            });
-        });
-    
+  continueButton.addEventListener('click', () => {
+    window.location.href = 'questions.html';
+  });
+});

--- a/js/message.js
+++ b/js/message.js
@@ -1,0 +1,59 @@
+(function () {
+  function showMessage(text, type = 'info') {
+    const box = document.createElement('div');
+    box.className = `message-box ${type}`;
+    Object.assign(box.style, {
+      position: 'fixed',
+      bottom: '80px',
+      left: '50%',
+      transform: 'translateX(-50%)',
+      background: 'var(--text)',
+      color: 'var(--bg)',
+      padding: '15px 25px',
+      borderRadius: '8px',
+      boxShadow: '0 4px 15px var(--shadow)',
+      zIndex: '1000',
+      opacity: '0',
+      transition: 'opacity .3s ease'
+    });
+    box.textContent = text;
+    document.body.appendChild(box);
+    requestAnimationFrame(() => {
+      box.style.opacity = '1';
+    });
+    setTimeout(() => {
+      box.style.opacity = '0';
+      box.addEventListener('transitionend', () => box.remove());
+    }, 3000);
+  }
+
+  function showConfirm(text) {
+    return new Promise((resolve) => {
+      const box = document.createElement('div');
+      box.className = 'message-box confirm';
+      Object.assign(box.style, {
+        position: 'fixed',
+        bottom: '80px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'var(--text)',
+        color: 'var(--bg)',
+        padding: '20px',
+        borderRadius: '8px',
+        boxShadow: '0 4px 15px var(--shadow)',
+        zIndex: '1000'
+      });
+      box.innerHTML = `<p style="margin-bottom:10px;">${text}</p>`+
+        '<div style="display:flex;gap:10px;justify-content:center;">'+
+        '<button id="confirm-yes" class="nav-button" style="flex:0 0 auto;">Yes</button>'+ 
+        '<button id="confirm-no" class="nav-button" style="flex:0 0 auto;">No</button>'+ 
+        '</div>';
+      document.body.appendChild(box);
+      box.querySelector('#confirm-yes').addEventListener('click', () => { box.remove(); resolve(true); });
+      box.querySelector('#confirm-no').addEventListener('click', () => { box.remove(); resolve(false); });
+    });
+  }
+
+  window.showMessage = showMessage;
+  window.showConfirm = showConfirm;
+})();

--- a/js/name.js
+++ b/js/name.js
@@ -1,43 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('isOnboarded') === 'true') {
+    window.location.href = 'generator.html';
+    return;
+  }
 
-        document.addEventListener('DOMContentLoaded', () => {
-        // 🔁 data-dark-src swap logic
-        document.querySelectorAll("img[data-dark-src]").forEach(img => {
-          if (document.body.classList.contains("dark-mode")) {
-            img.src = img.dataset.darkSrc;
-          }
-        });
-            // Apply theme based on localStorage
-            const theme = localStorage.getItem('theme');
-            if (theme === 'dark') {
-                document.body.classList.add('dark-mode');
-            }
+  const nameInput = document.getElementById('name-input');
+  const continueButton = document.getElementById('continue-button');
 
-            const nameInput = document.getElementById('name-input');
-            const continueButton = document.getElementById('continue-button');
+  function update() {
+    continueButton.disabled = !nameInput.value.trim();
+  }
 
-            /**
-             * Checks if the name input field has text and enables/disables the continue button.
-             */
-            const checkNameInput = () => {
-                continueButton.disabled = !nameInput.value.trim();
-            };
+  nameInput.addEventListener('input', update);
+  update();
 
-            // Add event listener for input changes
-            nameInput.addEventListener('input', checkNameInput);
-            // Initial check on page load to set button state
-            checkNameInput();
+  continueButton.addEventListener('click', () => {
+    const name = nameInput.value.trim();
+    if (!name) return;
+    localStorage.setItem('userName', name);
+    window.location.href = 'intro.html';
+  });
 
-            // Event listener for the "Continue" button
-            continueButton.addEventListener('click', () => {
-                const name = nameInput.value.trim();
-                if (name) {
-                    localStorage.setItem('userName', name);
-                    // Navigate to the next onboarding page
-                    window.location.href = 'intro.html';
-                }
-            });
-
-            // Set focus to the input field on load for better UX
-            nameInput.focus();
-        });
-    
+  nameInput.focus();
+});

--- a/js/onboard-settings.js
+++ b/js/onboard-settings.js
@@ -1,186 +1,90 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('isOnboarded') === 'true') {
+    window.location.href = 'generator.html';
+    return;
+  }
 
-        document.addEventListener('DOMContentLoaded', async () => {
-        // 🔁 data-dark-src swap logic
-        document.querySelectorAll("img[data-dark-src]").forEach(img => {
-          if (document.body.classList.contains("dark-mode")) {
-            img.src = img.dataset.darkSrc;
-          }
-        });
-            // Apply theme based on localStorage
-            const theme = localStorage.getItem('theme');
-            if (theme === 'dark') {
-                document.body.classList.add('dark-mode');
-            }
+  const apiKeyInput = document.getElementById('openrouter-api-key');
+  const modelSelect = document.getElementById('openrouter-model-select');
+  const filterFree = document.getElementById('filter-free-models');
+  const spinner = document.getElementById('model-loading-spinner');
+  const contentTypeSelect = document.getElementById('content-type-select');
+  const prevButton = document.getElementById('prev-button');
+  const nextButton = document.getElementById('next-button');
 
-            const openrouterApiKeyInput = document.getElementById('openrouter-api-key');
-            const openrouterModelSelect = document.getElementById('openrouter-model-select');
-            const filterFreeModelsCheckbox = document.getElementById('filter-free-models');
-            const modelLoadingSpinner = document.getElementById('model-loading-spinner');
-            const contentTypeSelect = document.getElementById('content-type-select');
+  let allModels = [];
+  const debounce = (fn, delay = 500) => { let t; return (...a) => { clearTimeout(t); t = setTimeout(() => fn(...a), delay); }; };
 
-            const prevButton = document.getElementById('prev-button');
-            const nextButton = document.getElementById('next-button');
+  async function fetchModels() {
+    const key = apiKeyInput.value.trim();
+    if (!key) return;
+    spinner.style.display = 'block';
+    modelSelect.disabled = true;
+    modelSelect.innerHTML = '<option value="">Loading models...</option>';
+    try {
+      const resp = await fetch('https://openrouter.ai/api/v1/models', {
+        headers: { 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json' }
+      });
+      if (!resp.ok) throw new Error(resp.statusText);
+      const data = await resp.json();
+      allModels = data.data.map(m => ({ id: m.id, name: m.name, free: m.pricing?.prompt === 0 && m.pricing?.completion === 0 }));
+    } catch (e) {
+      showMessage(`Failed to load models: ${e.message}`, 'error');
+      allModels = [];
+    } finally {
+      spinner.style.display = 'none';
+      modelSelect.disabled = false;
+      populateModels();
+    }
+  }
 
-            let allOpenRouterModels = []; // To store all fetched models
+  const debouncedFetch = debounce(fetchModels);
 
-            // --- API Call to OpenRouter Models ---
-            async function fetchOpenRouterModels() {
-                modelLoadingSpinner.style.display = 'block'; // Show spinner
-                openrouterModelSelect.innerHTML = '<option value="">Loading models...</option>'; // Show loading text
-                openrouterModelSelect.disabled = true; // Disable select during load
+  function populateModels() {
+    modelSelect.innerHTML = '';
+    let models = allModels;
+    if (filterFree.checked) models = models.filter(m => m.free);
+    if (models.length === 0) {
+      modelSelect.innerHTML = '<option value="">No models found</option>';
+    } else {
+      models.sort((a, b) => a.name.localeCompare(b.name));
+      models.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.id;
+        opt.textContent = m.name;
+        modelSelect.appendChild(opt);
+      });
+    }
+    const stored = JSON.parse(localStorage.getItem('appSettings') || '{}');
+    if (stored.selectedModel) modelSelect.value = stored.selectedModel;
+    updateState();
+  }
 
-                try {
-                    const response = await fetch('https://openrouter.ai/api/v1/models', {
-                        headers: {
-                            'Authorization': `Bearer ${openrouterApiKeyInput.value.trim()}`,
-                            'Content-Type': 'application/json'
-                        }
-                    });
+  function updateState() {
+    const ok = apiKeyInput.value.trim() && modelSelect.value && contentTypeSelect.value;
+    nextButton.disabled = !ok;
+  }
 
-                    if (!response.ok) {
-                        const errorData = await response.json();
-                        throw new Error(`Failed to fetch models: ${response.status} - ${errorData.message || response.statusText}`);
-                    }
+  apiKeyInput.addEventListener('input', () => { updateState(); debouncedFetch(); });
+  modelSelect.addEventListener('change', updateState);
+  contentTypeSelect.addEventListener('change', updateState);
+  filterFree.addEventListener('change', populateModels);
 
-                    const data = await response.json();
-                    // Filter and map models from OpenRouter API response
-                    allOpenRouterModels = data.data.map(model => ({
-                        id: model.id,
-                        name: model.name,
-                        // OpenRouter provides 'pricing' object; check if it has a 'free' property or equivalent
-                        free: model.pricing && model.pricing.prompt && model.pricing.prompt === 0 && model.pricing.completion && model.pricing.completion === 0
-                    }));
+  prevButton.addEventListener('click', () => { window.location.href = 'questions.html'; });
+  nextButton.addEventListener('click', () => {
+    const appSettings = { apiKey: apiKeyInput.value.trim(), selectedModel: modelSelect.value, contentType: contentTypeSelect.value };
+    localStorage.setItem('appSettings', JSON.stringify(appSettings));
+    localStorage.setItem('isOnboarded', 'true');
+    window.location.href = 'generator.html';
+  });
 
-                } catch (error) {
-                    console.error("Error fetching OpenRouter models:", error);
-                    // Display an error message to the user
-                    displayMessage(`Failed to load models: ${error.message}. Check your API Key or network.`, "error");
-                    openrouterModelSelect.innerHTML = '<option value="">Error loading models</option>';
-                    allOpenRouterModels = []; // Clear models on error
-                } finally {
-                    modelLoadingSpinner.style.display = 'none'; // Hide spinner
-                    openrouterModelSelect.disabled = false; // Enable select
-                    populateModelDropdown(); // Populate dropdown with fetched (or error) models
-                }
-            }
-
-            // --- Populate Model Dropdown ---
-            function populateModelDropdown() {
-                openrouterModelSelect.innerHTML = ''; // Clear previous options
-                let modelsToDisplay = allOpenRouterModels;
-
-                if (filterFreeModelsCheckbox.checked) {
-                    modelsToDisplay = allOpenRouterModels.filter(model => model.free);
-                }
-
-                if (modelsToDisplay.length === 0) {
-                    openrouterModelSelect.innerHTML = '<option value="">No models found with current filter.</option>';
-                    nextButton.disabled = true; // Disable next if no models available
-                    return;
-                }
-
-                // Sort models alphabetically by name
-                modelsToDisplay.sort((a, b) => a.name.localeCompare(b.name));
-
-                modelsToDisplay.forEach(model => {
-                    const option = document.createElement('option');
-                    option.value = model.id;
-                    option.textContent = model.name;
-                    openrouterModelSelect.appendChild(option);
-                });
-
-                // Set previously selected model if available
-                const storedSettings = JSON.parse(localStorage.getItem('appSettings')) || {};
-                openrouterModelSelect.value = storedSettings.selectedModel || '';
-
-                // Update next button state after populating
-                updateNextButtonState();
-            }
-
-            // --- Update Next Button State (Validation) ---
-            function updateNextButtonState() {
-                const isApiKeyEntered = openrouterApiKeyInput.value.trim() !== '';
-                const isModelSelected = openrouterModelSelect.value !== '';
-                const isContentTypeSelected = contentTypeSelect.value !== '';
-
-                nextButton.disabled = !(isApiKeyEntered && isModelSelected && isContentTypeSelected);
-            }
-
-            // --- Event Listeners ---
-            openrouterApiKeyInput.addEventListener('input', () => {
-                updateNextButtonState();
-                // Re-fetch models if API key changes (optional, but useful)
-                // Debounce this in a real app to prevent too many calls
-                if (openrouterApiKeyInput.value.trim().length > 10) { // Simple heuristic
-                    fetchOpenRouterModels();
-                }
-            });
-            openrouterModelSelect.addEventListener('change', updateNextButtonState);
-            contentTypeSelect.addEventListener('change', updateNextButtonState);
-            filterFreeModelsCheckbox.addEventListener('change', () => {
-                populateModelDropdown(); // Re-populate when filter changes
-            });
-
-            prevButton.addEventListener('click', () => {
-                // Navigate back to the last onboarding question (improve)
-                window.location.href = 'questions.html'; // Corrected navigation
-            });
-
-            nextButton.addEventListener('click', () => {
-                // Save settings to localStorage
-                const appSettings = {
-                    apiKey: openrouterApiKeyInput.value.trim(),
-                    selectedModel: openrouterModelSelect.value,
-                    contentType: contentTypeSelect.value
-                };
-                localStorage.setItem('appSettings', JSON.stringify(appSettings));
-                localStorage.setItem('isOnboarded', 'true'); // Mark onboarding as complete
-
-                // Navigate to the main generator page
-                window.location.href = 'generator.html';
-            });
-
-            // Custom message box function (reused from onboarding)
-            function displayMessage(message, type = "info") {
-                const messageBox = document.createElement('div');
-                messageBox.classList.add('message-box', type);
-                messageBox.textContent = message;
-                document.body.appendChild(messageBox);
-
-                messageBox.style.opacity = 0; // Start invisible for transition
-                if (document.body.classList.contains('dark-mode')) {
-                    messageBox.style.backgroundColor = '#F7F7D3';
-                    messageBox.style.color = '#000000';
-                }
-
-                setTimeout(() => { messageBox.style.opacity = 1; }, 10);
-                setTimeout(() => {
-                    messageBox.style.opacity = 0;
-                    messageBox.addEventListener('transitionend', () => messageBox.remove());
-                }, 3000);
-            }
-
-            // --- Initial Load ---
-            // Load existing settings if they exist
-            const storedSettings = JSON.parse(localStorage.getItem('appSettings')) || {};
-            if (storedSettings.apiKey) {
-                openrouterApiKeyInput.value = storedSettings.apiKey;
-            }
-            if (storedSettings.selectedModel) {
-                // Model will be set after fetchOpenRouterModels completes
-            }
-            if (storedSettings.contentType) {
-                contentTypeSelect.value = storedSettings.contentType;
-            }
-
-            // Fetch models on page load if an API key is present
-            // Or if the API key input is empty, don't auto-fetch, wait for user input
-            if (openrouterApiKeyInput.value.trim() !== '') {
-                fetchOpenRouterModels();
-            } else {
-                 openrouterModelSelect.innerHTML = '<option value="">Enter API Key to load models</option>';
-                 openrouterModelSelect.disabled = true;
-                 updateNextButtonState(); // Ensure button is disabled if API key is missing
-            }
-        });
-    
+  const stored = JSON.parse(localStorage.getItem('appSettings') || '{}');
+  if (stored.apiKey) apiKeyInput.value = stored.apiKey;
+  if (stored.contentType) contentTypeSelect.value = stored.contentType;
+  if (apiKeyInput.value.trim()) fetchModels();
+  else {
+    modelSelect.innerHTML = '<option value="">Enter API Key to load models</option>';
+    modelSelect.disabled = true;
+    updateState();
+  }
+});

--- a/js/questions.js
+++ b/js/questions.js
@@ -1,15 +1,8 @@
 
-        document.addEventListener('DOMContentLoaded', () => {
-        // 🔁 data-dark-src swap logic
-        document.querySelectorAll("img[data-dark-src]").forEach(img => {
-          if (document.body.classList.contains("dark-mode")) {
-            img.src = img.dataset.darkSrc;
-          }
-        });
-            // Apply theme based on localStorage
-            const theme = localStorage.getItem('theme');
-            if (theme === 'dark') {
-                document.body.classList.add('dark-mode');
+document.addEventListener('DOMContentLoaded', () => {
+            if (localStorage.getItem('isOnboarded') === 'true') {
+                window.location.href = 'generator.html';
+                return;
             }
 
             // Get all question containers
@@ -130,14 +123,14 @@
                     // Multiple choice validation
                     if (userProfileData[questionIdentifier] === undefined) { // Check for undefined, not just falsy
                         // Using a custom modal/message box instead of alert()
-                        displayMessage("Please select an option before proceeding.", "warning");
+                        showMessage("Please select an option before proceeding.", "warning");
                         isValid = false;
                     }
                 } else if (currentQuestionContainer.querySelector('textarea')) {
                     // Open-ended validation
                     const textareaId = currentQuestionContainer.querySelector('textarea').id;
                     if (!userProfileData[textareaId] || userProfileData[textareaId].trim() === '') {
-                        displayMessage("Please fill out this field before proceeding.", "warning");
+                        showMessage("Please fill out this field before proceeding.", "warning");
                         isValid = false;
                     }
                 }
@@ -167,48 +160,6 @@
                     showQuestion(currentQuestionIndex);
                 }
             });
-
-            // Custom message box function (replaces alert())
-            function displayMessage(message, type = "info") {
-                const messageBox = document.createElement('div');
-                messageBox.classList.add('message-box', type);
-                messageBox.textContent = message;
-                document.body.appendChild(messageBox);
-
-                // Basic styling for the message box
-                messageBox.style.cssText = `
-                    position: fixed;
-                    bottom: 80px; /* Adjusted: Above the new, lower fixed footer */
-                    left: 50%;
-                    transform: translateX(-50%);
-                    background-color: #000000;
-                    color: #FFFFE3;
-                    padding: 15px 25px;
-                    border-radius: 8px;
-                    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
-                    z-index: 1000;
-                    font-family: 'Special Elite', monospace;
-                    opacity: 0;
-                    transition: opacity 0.3s ease-in-out;
-                    max-width: 80%;
-                    text-align: center;
-                `;
-                // Dark mode adjustment for message box
-                if (document.body.classList.contains('dark-mode')) {
-                    messageBox.style.backgroundColor = '#FFFFE3';
-                    messageBox.style.color = '#000000';
-                }
-
-                setTimeout(() => {
-                    messageBox.style.opacity = 1;
-                }, 10); // Small delay to trigger transition
-
-                setTimeout(() => {
-                    messageBox.style.opacity = 0;
-                    messageBox.addEventListener('transitionend', () => messageBox.remove());
-                }, 3000); // Message disappears after 3 seconds
-            }
-
 
             // Initial display of the first question
             showQuestion(currentQuestionIndex);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,245 +1,98 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('isOnboarded') !== 'true') {
+    window.location.href = 'index.html';
+    return;
+  }
 
-        document.addEventListener('DOMContentLoaded', async () => {
-            const body = document.body;
-            const openrouterApiKeyInput = document.getElementById('openrouter-api-key');
-            const openrouterModelSelect = document.getElementById('openrouter-model-select');
-            const filterFreeModelsCheckbox = document.getElementById('filter-free-models');
-            const modelLoadingSpinner = document.getElementById('model-loading-spinner');
-            const contentTypeSelect = document.getElementById('content-type-select');
-            const deleteDataButton = document.getElementById('delete-data-button');
-            const backToGeneratorButton = document.getElementById('back-to-generator-button');
-            const saveSettingsButton = document.getElementById('save-settings-button');
-            const themeToggleCheckbox = document.getElementById('theme-toggle-checkbox');
+  const apiKeyInput = document.getElementById('openrouter-api-key');
+  const modelSelect = document.getElementById('openrouter-model-select');
+  const filterFree = document.getElementById('filter-free-models');
+  const spinner = document.getElementById('model-loading-spinner');
+  const contentTypeSelect = document.getElementById('content-type-select');
+  const deleteBtn = document.getElementById('delete-data-button');
+  const backBtn = document.getElementById('back-to-generator-button');
+  const saveBtn = document.getElementById('save-settings-button');
 
-            let allOpenRouterModels = []; // To store all fetched models
+  let allModels = [];
+  const debounce = (fn, delay = 500) => { let t; return (...a) => { clearTimeout(t); t = setTimeout(() => fn(...a), delay); }; };
 
-            // --- Custom Message Box (reused) ---
-            function displayMessage(message, type = "info") {
-                if (type === "confirm") {
-                    return new Promise((resolve) => {
-                        const confirmBox = document.createElement('div');
-                        confirmBox.classList.add('message-box', 'confirm');
-                        confirmBox.innerHTML = `
-                            <p>${message}</p>
-                            <div style="margin-top: 15px; display: flex; justify-content: center; gap: 10px;">
-                                <button id="confirm-yes" class="nav-button" style="flex-grow: 0; padding: 8px 15px;">Yes</button>
-                                <button id="confirm-no" class="nav-button" style="flex-grow: 0; padding: 8px 15px;">No</button>
-                            </div>
-                        `;
-                        document.body.appendChild(confirmBox);
+  async function fetchModels() {
+    const key = apiKeyInput.value.trim();
+    if (!key) return;
+    spinner.style.display = 'block';
+    modelSelect.disabled = true;
+    modelSelect.innerHTML = '<option value="">Loading models...</option>';
+    try {
+      const resp = await fetch('https://openrouter.ai/api/v1/models', {
+        headers: { 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json' }
+      });
+      if (!resp.ok) throw new Error(resp.statusText);
+      const data = await resp.json();
+      allModels = data.data.map(m => ({ id: m.id, name: m.name, free: m.pricing?.prompt === 0 && m.pricing?.completion === 0 }));
+    } catch (e) {
+      showMessage(`Failed to load models: ${e.message}`, 'error');
+      allModels = [];
+    } finally {
+      spinner.style.display = 'none';
+      modelSelect.disabled = false;
+      populateModels();
+    }
+  }
 
-                        // Apply correct button styles based on theme
-                        const confirmYesBtn = confirmBox.querySelector('#confirm-yes');
-                        const confirmNoBtn = confirmBox.querySelector('#confirm-no');
-                        confirmYesBtn.style.backgroundColor = '#9E001C'; // Yes button is always red
+  const debouncedFetch = debounce(fetchModels);
 
-                        if (body.classList.contains('dark-mode')) {
-                           confirmNoBtn.style.backgroundColor = '#FFFFE3';
-                           confirmNoBtn.style.color = '#000000';
-                        } else {
-                           confirmNoBtn.style.backgroundColor = '#000000';
-                           confirmNoBtn.style.color = '#FFFFE3';
-                        }
+  function populateModels() {
+    modelSelect.innerHTML = '';
+    let models = allModels;
+    if (filterFree.checked) models = models.filter(m => m.free);
+    if (models.length === 0) {
+      modelSelect.innerHTML = '<option value="">No models found</option>';
+    } else {
+      models.sort((a, b) => a.name.localeCompare(b.name));
+      models.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.id;
+        opt.textContent = m.name;
+        modelSelect.appendChild(opt);
+      });
+    }
+    const stored = JSON.parse(localStorage.getItem('appSettings') || '{}');
+    if (stored.selectedModel) modelSelect.value = stored.selectedModel;
+    updateState();
+  }
 
-                        confirmBox.style.opacity = 0;
-                        setTimeout(() => { confirmBox.style.opacity = 1; }, 10);
+  function updateState() {
+    const ok = apiKeyInput.value.trim() && modelSelect.value && contentTypeSelect.value;
+    saveBtn.disabled = !ok;
+  }
 
-                        confirmYesBtn.addEventListener('click', () => { confirmBox.remove(); resolve(true); });
-                        confirmNoBtn.addEventListener('click', () => { confirmBox.remove(); resolve(false); });
-                    });
-                } else {
-                    // Standard message box (info, success, error)
-                    const messageBox = document.createElement('div');
-                    messageBox.classList.add('message-box', type);
-                    messageBox.textContent = message;
-                    document.body.appendChild(messageBox);
+  apiKeyInput.addEventListener('input', () => { updateState(); debouncedFetch(); });
+  modelSelect.addEventListener('change', updateState);
+  contentTypeSelect.addEventListener('change', updateState);
+  filterFree.addEventListener('change', populateModels);
 
-                    messageBox.style.opacity = 0;
-                    if (body.classList.contains('dark-mode')) {
-                        messageBox.style.backgroundColor = '#FFFFE3';
-                        messageBox.style.color = '#000000';
-                    }
+  backBtn.addEventListener('click', () => { window.location.href = 'generator.html'; });
+  saveBtn.addEventListener('click', () => {
+    const appSettings = { apiKey: apiKeyInput.value.trim(), selectedModel: modelSelect.value, contentType: contentTypeSelect.value };
+    localStorage.setItem('appSettings', JSON.stringify(appSettings));
+    showMessage('Settings saved', 'info');
+  });
 
-                    setTimeout(() => { messageBox.style.opacity = 1; }, 10);
-                    setTimeout(() => {
-                        messageBox.style.opacity = 0;
-                        messageBox.addEventListener('transitionend', () => messageBox.remove());
-                    }, 3000);
-                }
-            }
+  deleteBtn.addEventListener('click', async () => {
+    const ok = await showConfirm('Delete all data and restart?');
+    if (ok) {
+      localStorage.clear();
+      window.location.href = 'index.html';
+    }
+  });
 
-            // --- Theme Handling ---
-            function applyTheme(theme) {
-                const lightIcon = document.getElementById('light-icon');
-                const darkIcon = document.getElementById('dark-icon');
-                
-                if (!body) return;
-                
-                if (theme === 'dark') {
-                    body.classList.add('dark-mode');
-                    if (lightIcon) lightIcon.style.display = 'none';
-                    if (darkIcon) darkIcon.style.display = 'inline-block';
-                } else {
-                    body.classList.remove('dark-mode');
-                    if (lightIcon) lightIcon.style.display = 'inline-block';
-                    if (darkIcon) darkIcon.style.display = 'none';
-                }
-                localStorage.setItem('theme', theme);
-            }
-
-            // --- API Call to OpenRouter Models ---
-            async function fetchOpenRouterModels() {
-                modelLoadingSpinner.style.display = 'block';
-                openrouterModelSelect.innerHTML = '<option value="">Loading models...</option>';
-                openrouterModelSelect.disabled = true;
-
-                const currentApiKey = openrouterApiKeyInput.value.trim();
-                console.log("Attempting to fetch OpenRouter models with API Key:", currentApiKey ? "Key present" : "Key missing"); // Diagnostic log
-
-                if (!currentApiKey) {
-                    displayMessage("Please enter an OpenRouter API Key to load models.", "warning");
-                    openrouterModelSelect.innerHTML = '<option value="">Enter API Key</option>';
-                    modelLoadingSpinner.style.display = 'none';
-                    openrouterModelSelect.disabled = true;
-                    return;
-                }
-
-                try {
-                    const response = await fetch('https://openrouter.ai/api/v1/models', {
-                        headers: {
-                            'Authorization': `Bearer ${currentApiKey}`,
-                            'Content-Type': 'application/json'
-                        }
-                    });
-
-                    if (!response.ok) {
-                        const errorData = await response.json();
-                        throw new Error(`Failed to fetch models: ${response.status} - ${errorData.message || response.statusText}`);
-                    }
-
-                    const data = await response.json();
-                    allOpenRouterModels = data.data.map(model => ({
-                        id: model.id,
-                        name: model.name,
-                        free: model.pricing && model.pricing.prompt && model.pricing.prompt === 0 && model.pricing.completion && model.pricing.completion === 0
-                    }));
-                    console.log("Models fetched successfully:", allOpenRouterModels.length); // Diagnostic log
-
-                } catch (error) {
-                    console.error("Error fetching OpenRouter models:", error); // Detailed error log
-                    displayMessage(`Failed to load models: ${error.message}. Check your API Key or network.`, "error");
-                    openrouterModelSelect.innerHTML = '<option value="">Error loading models</option>';
-                    allOpenRouterModels = [];
-                } finally {
-                    modelLoadingSpinner.style.display = 'none';
-                    openrouterModelSelect.disabled = false;
-                    populateModelDropdown();
-                }
-            }
-
-            // --- Populate Model Dropdown ---
-            function populateModelDropdown() {
-                openrouterModelSelect.innerHTML = '';
-                let modelsToDisplay = allOpenRouterModels;
-
-                if (filterFreeModelsCheckbox.checked) {
-                    modelsToDisplay = allOpenRouterModels.filter(model => model.free);
-                }
-
-                if (modelsToDisplay.length === 0) {
-                    openrouterModelSelect.innerHTML = '<option value="">No models found with current filter.</option>';
-                } else {
-                    modelsToDisplay.sort((a, b) => a.name.localeCompare(b.name));
-
-                    modelsToDisplay.forEach(model => {
-                        const option = document.createElement('option');
-                        option.value = model.id;
-                        option.textContent = model.name;
-                        openrouterModelSelect.appendChild(option);
-                    });
-                }
-                const storedSettings = JSON.parse(localStorage.getItem('appSettings')) || {};
-                openrouterModelSelect.value = storedSettings.selectedModel || '';
-
-                updateSaveButtonState();
-            }
-
-            // --- Update Save Button State (Validation) ---
-            function updateSaveButtonState() {
-                const isApiKeyEntered = openrouterApiKeyInput.value.trim() !== '';
-                const isModelSelected = openrouterModelSelect.value !== '';
-                const isContentTypeSelected = contentTypeSelect.value !== '';
-
-                saveSettingsButton.disabled = !(isApiKeyEntered && isModelSelected && isContentTypeSelected);
-            }
-
-            // --- Load Settings on Init ---
-            const initialSettings = JSON.parse(localStorage.getItem('appSettings')) || {};
-            if (initialSettings.apiKey) {
-                openrouterApiKeyInput.value = initialSettings.apiKey;
-            }
-            if (initialSettings.contentType) {
-                contentTypeSelect.value = initialSettings.contentType;
-            }
-            // IMPORTANT: Call applyTheme before fetchOpenRouterModels to ensure checkbox state is correct
-            applyTheme(localStorage.getItem('theme') || 'light');
-
-            if (openrouterApiKeyInput.value.trim() !== '') {
-                await fetchOpenRouterModels();
-            } else {
-                openrouterModelSelect.innerHTML = '<option value="">Enter API Key to load models</option>';
-                openrouterModelSelect.disabled = true;
-            }
-            updateSaveButtonState();
-
-            // --- Event Listeners ---
-            openrouterApiKeyInput.addEventListener('input', updateSaveButtonState);
-            openrouterApiKeyInput.addEventListener('blur', () => {
-                const currentVal = openrouterApiKeyInput.value.trim();
-                // Only fetch if key actually changed OR if it was previously empty and now has content
-                // Also check if currentVal is different from the currently displayed input value
-                if (currentVal !== initialSettings.apiKey || (initialSettings.apiKey === undefined && currentVal !== '')) {
-                     // Adding a small debounce for re-fetching on blur to avoid too many calls
-                    setTimeout(() => fetchOpenRouterModels(), 300);
-                }
-            });
-
-            openrouterModelSelect.addEventListener('change', updateSaveButtonState);
-            filterFreeModelsCheckbox.addEventListener('change', populateModelDropdown);
-            contentTypeSelect.addEventListener('change', updateSaveButtonState);
-
-            // Theme toggle via the new icons
-            document.getElementById('theme-toggle-icons').addEventListener('click', () => {
-                const currentTheme = localStorage.getItem('theme') || 'light';
-                const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-                applyTheme(newTheme);
-            });
-
-            // --- Data Deletion ---
-            deleteDataButton.addEventListener('click', async () => {
-                const confirmed = await displayMessage("Are you sure you want to delete all your data? This action cannot be undone.", "confirm");
-                if (confirmed) {
-                    localStorage.clear();
-                    displayMessage("All data has been deleted. Redirecting to start.", "info");
-                    setTimeout(() => {
-                        window.location.href = 'index.html'; // Redirect to start page
-                    }, 1000);
-                }
-            });
-
-            // --- Navigation Buttons ---
-            backToGeneratorButton.addEventListener('click', () => {
-                window.location.href = 'index.html'; // Go back to the generator
-            });
-
-            saveSettingsButton.addEventListener('click', () => {
-                const appSettings = {
-                    apiKey: openrouterApiKeyInput.value.trim(),
-                    selectedModel: openrouterModelSelect.value,
-                    contentType: contentTypeSelect.value
-                };
-                localStorage.setItem('appSettings', JSON.stringify(appSettings));
-                displayMessage("Settings saved successfully!", "info");
-            });
-        });
-    
+  const stored = JSON.parse(localStorage.getItem('appSettings') || '{}');
+  if (stored.apiKey) apiKeyInput.value = stored.apiKey;
+  if (stored.contentType) contentTypeSelect.value = stored.contentType;
+  if (apiKeyInput.value.trim()) fetchModels();
+  else {
+    modelSelect.innerHTML = '<option value="">Enter API Key to load models</option>';
+    modelSelect.disabled = true;
+    updateState();
+  }
+});

--- a/name.html
+++ b/name.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -34,21 +22,23 @@
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
-        <!-- Using logo.png as per previous file uploads, added onerror for robustness -->
-        <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/FFFFE3?text=Logo'" data-dark-src="assets/logo-dark.png">
+        <img id="logo" src="assets/logo.png"
+             data-light-src="assets/logo.png"
+             data-dark-src="assets/logo-dark.png"
+             alt="Artificial —and— Talentless Logo">
     </div>
 
     <!-- Main content area that will center the heading and input vertically -->
     <div id="main-content-area">
         <h1 id="name-main">What should I call you?</h1>
         <div class="input-container">
-            <input type="text" id="name-input" placeholder="Your name here...">
+            <input type="text" id="name-input" placeholder="Your name here..." aria-label="Your name">
         </div>
     </div>
 
     <!-- Footer for the button, fixed at the bottom -->
     <div id="button-footer">
-        <button id="continue-button" class="nav-button">Continue</button>
+        <button id="continue-button" class="nav-button" disabled>Continue</button>
     </div>
 
     <script src="js/name.js"></script>

--- a/onboard-settings.html
+++ b/onboard-settings.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Settings</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -34,7 +22,10 @@
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
-        <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/F7F7D3?text=Logo'" data-dark-src="assets/logo-dark.png">
+        <img id="logo" src="assets/logo.png"
+             data-light-src="assets/logo.png"
+             data-dark-src="assets/logo-dark.png"
+             alt="Artificial —and— Talentless Logo">
     </div>
 
     <!-- Main content area for displaying settings, centered vertically -->
@@ -77,10 +68,11 @@
 
     <!-- Global Footer for Navigation Buttons, fixed at the bottom -->
     <div id="button-footer">
-        <button id="prev-button" class="nav-button">Prev</button>
-        <button id="next-button" class="nav-button">Finish</button>
+        <button id="prev-button" class="nav-button" disabled>Prev</button>
+        <button id="next-button" class="nav-button" disabled>Finish</button>
     </div>
 
+    <script src="js/message.js"></script>
     <script src="js/onboard-settings.js"></script>
     <script src="js/pwa.js"></script>
     <script src="js/theme.js"></script>

--- a/questions.html
+++ b/questions.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Onboarding</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -34,8 +22,10 @@
     </div>
     <!-- Container for the logo, fixed at the top of the viewport -->
     <div id="logo-container">
-        <!-- Using logo.jpg as per previous file uploads, added onerror for robustness -->
-        <img id="logo" src="assets/logo.png" alt="Artificial -and- Talentless Logo" onerror="this.onerror=null; this.src='https://placehold.co/350x80/1A1A1A/FFFFE3?text=Logo'" data-dark-src="assets/logo-dark.png">
+        <img id="logo" src="assets/logo.png"
+             data-light-src="assets/logo.png"
+             data-dark-src="assets/logo-dark.png"
+             alt="Artificial —and— Talentless Logo">
     </div>
 
     <!-- Main content area for displaying questions, centered vertically -->
@@ -118,10 +108,11 @@
 
     <!-- Global Footer for Navigation Buttons, fixed at the bottom -->
     <div id="button-footer">
-        <button id="prev-button" class="nav-button">Prev</button>
-        <button id="next-button" class="nav-button">Next</button>
+        <button id="prev-button" class="nav-button" disabled>Prev</button>
+        <button id="next-button" class="nav-button" disabled>Next</button>
     </div>
 
+    <script src="js/message.js"></script>
     <script src="js/questions.js"></script>
     <script src="js/pwa.js"></script>
     <script src="js/theme.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="manifest.webmanifest">
     <title>Artificial -and- Talentless - Settings</title>
-    <script>
-      (function () {
-        const KEY = 'app:theme';
-        const stored = localStorage.getItem(KEY) || 'system';
-        const resolved = stored === 'system'
-          ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : stored;
-        const root = document.documentElement;
-        root.setAttribute('data-theme', resolved);
-        root.style.colorScheme = resolved;
-      })();
-    </script>
     <!-- Tailwind CSS CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome for icons -->
@@ -83,10 +71,11 @@
     <!-- Global Footer for Navigation Buttons, fixed at the bottom -->
     <div id="button-footer">
         <button id="back-to-generator-button" class="nav-button">Back</button>
-        <button id="save-settings-button" class="nav-button">Save</button>
+        <button id="save-settings-button" class="nav-button" disabled>Save</button>
     </div>
 
     <!-- At the bottom of settings.html, before </body> -->
+    <script src="js/message.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/pwa.js"></script>
     <script src="js/theme.js"></script>

--- a/style.css
+++ b/style.css
@@ -108,8 +108,8 @@ body {
 
 #header-content.global {
   position: fixed;
-  top: 5px;
-  left: 10%;
+  top: 10px;
+  left: 50%;
   transform: translateX(-50%);
   z-index: 10;
   width: 100%;
@@ -288,6 +288,11 @@ button:disabled, .nav-button:disabled {
   cursor: not-allowed;
   transform: none !important;
   opacity: .6;
+}
+
+button:focus-visible, .nav-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Variant: .nav-button (kept for compatibility, but it inherits above) */
@@ -533,18 +538,6 @@ h3 {
 
 
 /* Fix misaligned header (global) */
-#header-content.global {
-  position: fixed;
-  top: 10px;
-  left: 135%;           /* was 10% */
-  transform: translateX(-50%);
-  z-index: 10;
-  width: 100%;
-  max-width: 100%;
-  text-align: center;
-  padding: 0 var(--space-5);
-}
-
 .icon-btn {
   background: none;
   text-align: center;

--- a/sw.js
+++ b/sw.js
@@ -1,17 +1,15 @@
 // sw.js — robust install (skips missing files), same-origin only
-const CACHE_NAME = 'a-and-t-v7';
+const CACHE_NAME = 'a-and-t-v8';
 
-// Keep this list ONLY to files you actually serve.
-// I’ve removed /assets/* since that folder isn’t on your server right now.
-// Add them back later when those routes exist.
+// Same-origin files to precache
 const ASSETS = [
   '/', '/index.html', '/intro.html', '/name.html', '/questions.html',
   '/onboard-settings.html', '/generator.html', '/settings.html',
   '/style.css',
-  // your scripts are at project root (not /js/)
   'js/index.js','js/intro.js','js/name.js','js/questions.js',
   'js/onboard-settings.js','js/generator.js','js/settings.js',
-  'js/pwa.js','js/theme.js',
+  'js/pwa.js','js/theme.js','js/message.js',
+  '/assets/logo.png','/assets/logo-dark.png','/assets/icon.png','/assets/icon-dark.png',
   '/manifest.webmanifest'
 ];
 


### PR DESCRIPTION
## Summary
- streamline navigation flow with defensive button states and onboarding redirects
- centralize theme logic and logo swapping with `app:theme`
- harden service worker caching and add shared toast utilities

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a56cfdf81c832a9cff7c0add85aba2