### PR TITLE
Add theme toggle and delayed controls to generator page

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -14,6 +14,12 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div id="header-content" class="global">
+        <button id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle theme" class="icon-btn">
+            <i class="fas fa-sun" aria-hidden="true"></i>
+            <i class="fas fa-moon" aria-hidden="true"></i>
+        </button>
+    </div>
     <h1 class="sr-only">Generator</h1>
     <!-- Main content area for the loading message, spinner, or generated content -->
     <div id="main-content-area" class="generate">
@@ -22,9 +28,9 @@
     </div>
 
     <!-- Global Footer for Navigation Buttons, fixed at the bottom -->
-    <div id="button-footer">
+    <div id="button-footer" style="visibility: hidden;">
         <button id="generate-new-button" class="nav-button" disabled>Generate New</button>
-        <button id="settings-button" class="nav-button">Settings</button>
+        <button id="settings-button" class="nav-button" disabled>Settings</button>
     </div>
 
     <script src="js/message.js"></script>

--- a/js/generator.js
+++ b/js/generator.js
@@ -217,9 +217,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     displayContentElement.textContent = '';
                     displayContentElement.style.visibility = 'visible';
                     typeWriter(displayContentElement, generatedText, 0, () => {
-                        buttonFooter.style.visibility = 'visible';
-                        generateNewButton.disabled = false;
-                        settingsButton.disabled = false;
+                        setTimeout(() => {
+                            buttonFooter.style.visibility = 'visible';
+                            generateNewButton.disabled = false;
+                            settingsButton.disabled = false;
+                        }, 500);
                     });
                 } catch (error) {
                     console.error("Error generating content:", error);
@@ -228,11 +230,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     showMessage(msg, "error");
                     displayContentElement.textContent = "Error generating content. Maybe your life is too boring for AI?";
                     displayContentElement.style.visibility = 'visible';
-                } finally {
-                    loadingSpinner.style.display = 'none';
                     buttonFooter.style.visibility = 'visible';
                     generateNewButton.disabled = false;
                     settingsButton.disabled = false;
+                } finally {
+                    loadingSpinner.style.display = 'none';
                 }
                 
             }


### PR DESCRIPTION
## Summary
- Add global theme toggle to generator page so theme switching works everywhere
- Delay revealing generator controls until after content generation completes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a59f7249e0832ab28f8b7cde3e3c0c